### PR TITLE
Pylint refactors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 script:
   - pycodestyle --ignore=E501,W503 *.py ocfl tests
   - pydocstyle *.py ocfl tests
-  - pylint --disable=unneeded-not,line-too-long,unnecessary-semicolon,trailg-whitespace,missing-final-newline,bad-indentation,multiple-statements,bare-except,missing-module-docstring,missing-class-docstring,missing-function-docstring,W0511,W0622,W0707,C0103,R0902,R0911,R0912,R0913,R0914,R0915,R1702,R1714 *.py ocfl tests
+  - pylint --disable=unneeded-not,line-too-long,unnecessary-semicolon,trailg-whitespace,missing-final-newline,bad-indentation,multiple-statements,bare-except,missing-module-docstring,missing-class-docstring,missing-function-docstring,W0511,W0622,W0707,C0103,R0902,R0911,R0912,R0913,R0914,R0915,R1702 *.py ocfl tests
   - python setup.py test
 after_success:
   - python setup.py coverage

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 2021-??-?? v1.2.1
 
   * Add use of `pylint` in addition to `pycodestyle` and `pydocstyle` (was `pep257`). Numerous minor fixes as a result of errors/warnings reported.
+  * Use additional fixtures in https://github.com/OCFL/fixtures for tests
 
 ## 2021-03-24 v1.2.0
 
@@ -48,7 +49,7 @@
 ## 2020-05-18 v0.0.7
 
   * Validator now checks fixity block structure, additional fixity values in fixity block
-  * Validator now checks for repeated digests in manifest, fixity and state blocks (https://ocfl.io/1.0/spec/#E096, https://ocfl.io/1.0/spec/#E097, https://ocfl.io/1.0/spec/#E098) 
+  * Validator now checks for repeated digests in manifest, fixity and state blocks (https://ocfl.io/1.0/spec/#E096, https://ocfl.io/1.0/spec/#E097, https://ocfl.io/1.0/spec/#E098)
   * Move all the many README_*.md demos into docs folder
   * Add build_demo_docs.sh to build demo descriptions in docs folder
 
@@ -64,7 +65,7 @@
 
 ## 2020-05-05 v0.0.5
 
-  * Renumber errors to align somewhat with the canonical code set extracted 
+  * Renumber errors to align somewhat with the canonical code set extracted
     at https://github.com/OCFL/spec/blob/main/validation/validation-codes.md
   * Add --version parameter to scripts to show version number
 

--- a/ocfl/digest.py
+++ b/ocfl/digest.py
@@ -98,6 +98,6 @@ def normalized_digest(digest, digest_type='sha512'):
     All forms (except the spec example forms) are case insensitive. We
     use lowercase as the normalized form.
     """
-    if digest_type in ('sha512-spec-ex','sha256-spec-ex'):
+    if digest_type in ('sha512-spec-ex', 'sha256-spec-ex'):
         return digest
     return digest.lower()

--- a/ocfl/digest.py
+++ b/ocfl/digest.py
@@ -99,5 +99,5 @@ def normalized_digest(digest, digest_type='sha512'):
     use lowercase as the normalized form.
     """
     if digest_type in ('sha512-spec-ex','sha256-spec-ex'):
-        return digest.lower()
-    return digest
+        return digest
+    return digest.lower()

--- a/ocfl/digest.py
+++ b/ocfl/digest.py
@@ -98,6 +98,6 @@ def normalized_digest(digest, digest_type='sha512'):
     All forms (except the spec example forms) are case insensitive. We
     use lowercase as the normalized form.
     """
-    if digest_type != 'sha512-spec-ex' and digest_type != 'sha256-spec-ex':
+    if digest_type in ('sha512-spec-ex','sha256-spec-ex'):
         return digest.lower()
     return digest

--- a/ocfl/object_utils.py
+++ b/ocfl/object_utils.py
@@ -85,7 +85,7 @@ def remove_first_directory(path):
     rpath = ''
     while True:
         (head, tail) = fs.path.split(path)
-        if head == path or tail == path:
+        if path in (head, tail):
             break
         path = head
         rpath = tail if rpath == '' else fs.path.join(tail, rpath)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -56,8 +56,8 @@ class TestAll(unittest.TestCase):
                            'E096_manifest_repeated_digest': ['E096'],
                            'E097_fixity_repeated_digest': ['E097'],
                            'E099_bad_content_path_elements': ['E099'],
-                           'E100_E099_fixity_invalid_content_paths': ['E057d'],
-                           'E100_E099_manifest_invalid_content_paths': ['E099','E100']}.items():
+                           'E100_E099_fixity_invalid_content_paths': ['E057d'],  # E057 OK, different test approach
+                           'E100_E099_manifest_invalid_content_paths': ['E099', 'E100']}.items():
             v = Validator()
             filepath = 'fixtures/1.0/bad-objects/' + bad
             if not os.path.isdir(filepath):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -24,7 +24,8 @@ class TestAll(unittest.TestCase):
         for bad, codes in {'does_not_even_exist': ['E003c'],
                            'E001_extra_dir_in_root': ['E001b'],
                            'E001_extra_file_in_root': ['E001a'],
-                           'E003_E034_empty': ['E003a', 'E034'],
+                           'E001_v2_file_in_root': [],
+                           'E003_E063_empty': ['E003a', 'E034'],
                            'E003_no_decl': ['E003a'],
                            'E008_E036_no_versions_no_head': ['E008', 'E036d'],
                            'E009_version_two_only': ['E009'],
@@ -33,7 +34,6 @@ class TestAll(unittest.TestCase):
                            'E023_missing_file': ['E023a'],
                            'E024_empty_dir_in_content': ['E024'],
                            'E033_inventory_bad_json': ['E033'],
-                           'E034_no_inv': ['E034'],
                            'E036_no_id': ['E036a'],
                            'E040_wrong_head_doesnt_exist': ['E040'],
                            'E040_wrong_head_format': ['E040'],
@@ -47,6 +47,7 @@ class TestAll(unittest.TestCase):
                            'E050_file_in_manifest_not_used': ['E050b'],
                            'E050_state_repeated_digest': ['E050f'],
                            'E058_no_sidecar': ['E058a'],
+                           'E063_no_inv': ['E034'],  # FIXME https://github.com/zimeon/ocfl-py/issues/36
                            'E064_different_root_and_latest_inventories': ['E064'],
                            'E067_file_in_extensions_dir': ['E067'],
                            'E092_bad_manifest_digest': ['E092'],
@@ -54,7 +55,9 @@ class TestAll(unittest.TestCase):
                            'E095_conflicting_logical_paths': ['E095'],
                            'E096_manifest_repeated_digest': ['E096'],
                            'E097_fixity_repeated_digest': ['E097'],
-                           'E099_bad_content_path_elements': ['E099']}.items():
+                           'E099_bad_content_path_elements': ['E099'],
+                           'E100_E099_fixity_invalid_content_paths': ['E057d'],
+                           'E100_E099_manifest_invalid_content_paths': ['E099','E100']}.items():
             v = Validator()
             filepath = 'fixtures/1.0/bad-objects/' + bad
             if not os.path.isdir(filepath):
@@ -76,7 +79,8 @@ class TestAll(unittest.TestCase):
                             'W008_user_no_address': ['W008'],
                             'W009_user_address_not_uri': ['W009'],
                             'W010_no_version_inventory': ['W010'],
-                            'W011_version_inv_diff_metadata': ['W011']}.items():
+                            'W011_version_inv_diff_metadata': ['W011'],
+                            'W013_unregistered_extension': ['W013']}.items():
             v = Validator()
             filepath = 'fixtures/1.0/warn-objects/' + warn
             if not os.path.isdir(filepath):


### PR DESCRIPTION
Merge in first pass of changes to use `pylint`, still with quite a few suggested refactors excluded from tests