### PR TITLE
Update docs to say we use main instead of develop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ If submitting a pull request:
 
    * Understand that this code and any merged contributions are covered by the [MIT license](LICENSE.txt)
    * Please discuss in a issue before submitting a pull request for significant changes
-   * Please submit pull requests against the `develop` branch
+   * Please submit pull requests against the `main` branch
    * Please write code that passes the linting tests in `.travis.yml`, these include:
      * `pycodestyle` implements [PEP8](https://www.python.org/dev/peps/pep-0008/) with the following warnings disabled:
        * Line length is not enforced (E501), just be reasonable

--- a/README
+++ b/README
@@ -7,8 +7,6 @@ ocfl-py - An OCFL implementation in Python
 .. image:: https://coveralls.io/repos/github/zimeon/ocfl-py/badge.svg?branch=main
   :target: https://coveralls.io/github/zimeon/ocfl-py?branch=main
 
-**WORK IN PROGRESS - NO GUARANTEE, NO MONEY BACK :-)**
-
 Attempts to follow `OCFL specification v1.0
 <https://ocfl.io/1.0/spec/>`_, see `implementation status for errors and warnings
 <https://github.com/zimeon/ocfl-py/blob/main/docs/validation_status.md>`_ for
@@ -23,11 +21,14 @@ This code attempts to support the OCFL specification v1.0 and additional
 developments. To get the most up to date version check out the ``main``
 branch from github (or if you are reckless you can try the ``develop`` branch).
 
-I hope to keep a version not too far out of date on `PyPI
-<https://pypi.org/project/ocfl-py/>`_ too, which can be installed or upgraded
-to the current version with:
+I hope to keep a fairly current version on `PyPI
+<https://pypi.org/project/ocfl-py/>`_, which can be installed or upgraded
+with:
 
     pip install --upgrade ocfl-py
+
+The latest version is in the `main` branch on `github
+<https://github.com/zimeon/ocfl-py>`_.
 
 Use
 ---
@@ -37,14 +38,14 @@ There should then be three scripts available:
 - ``ocfl-validate.py`` - validate OCFL objects, OCFL storage roots or standalone OCFL inventory files
 - ``ocfl-object.py`` - build, manipulate, extract from or validate an OCFL object
 - ``ocfl-store.py`` - add or access OCFL objects under an OCFL storage root
+- ``ocfl-sidecar.py`` - update OCFL inventory sidecar file (useful for manually building examples and test cases)
 
 Each script takes ``-h`` for help.
 
 See `examples in docs folder
 <https://github.com/zimeon/ocfl-py/tree/main/docs>`_ for use of these scripts.
 
-The code is also available as a module ``ocfl`` for other python code to use. However,
-the interfaces should not be considered stable at the moment.
+The code is also available as a module ``ocfl`` for other python code to use.
 
 Contributing
 ------------

--- a/ocfl/_version.py
+++ b/ocfl/_version.py
@@ -1,2 +1,2 @@
 """Version number for this Python implementation of OCFL."""
-__version__ = '1.2.2'
+__version__ = '1.2.3'


### PR DESCRIPTION
Bump version to 1.2.3 and change to say use `main` as base for PRs